### PR TITLE
query game details

### DIFF
--- a/src/clients/gotd/index.test.ts
+++ b/src/clients/gotd/index.test.ts
@@ -35,6 +35,11 @@ const MOCK_GAME: Game = {
   expected_release_quarter: '',
   expected_release_year: '',
   original_release_date: '',
+  characters: [],
+  concepts: [],
+  developers: [],
+  guid: '123',
+  themes: [],
 };
 
 test('It fails if no token is provided', () => {
@@ -97,7 +102,17 @@ test('It returns a game', () => {
       return res.once(ctx.json({ error: 'OK', number_of_total_results: 100 }));
     }),
     rest.get('https://www.giantbomb.com/api/games/', (req, res, ctx) => {
-      return res.once(ctx.json({ error: 'OK', results: [MOCK_GAME] }));
+      return res.once(
+        ctx.json({
+          error: 'OK',
+          results: [
+            { api_detail_url: 'https://www.giantbomb.com/api/game/abc/' },
+          ],
+        }),
+      );
+    }),
+    rest.get('https://www.giantbomb.com/api/game/abc/', (req, res, ctx) => {
+      return res.once(ctx.json({ error: 'OK', results: MOCK_GAME }));
     }),
   );
 

--- a/src/clients/gotd/index.ts
+++ b/src/clients/gotd/index.ts
@@ -2,8 +2,10 @@ import fetch from 'isomorphic-unfetch';
 export { formatDateFromGame, selectImage } from './utils';
 
 export type GameImage = {
+  original_url?: string;
   super_url?: string;
   screen_url?: string;
+  screen_large_url?: string;
   medium_url?: string;
   small_url?: string;
   thumb_url?: string;
@@ -13,22 +15,47 @@ export type GameImage = {
 
 export type Game = {
   id: number;
-  image: GameImage;
+  guid: string;
+  image?: GameImage;
   name: string;
-  deck: string | null;
-  description: string | null;
+  deck?: string | null;
+  description?: string | null;
   original_release_date?: string;
-  site_detail_url: string;
+  site_detail_url?: string;
   expected_release_day?: string | null;
   expected_release_month?: string | null;
   expected_release_year?: string | null;
   expected_release_quarter?: string | null;
-  platforms: {
+  platforms?: {
     api_detail_url: string;
     id: number;
     name: string;
     site_detail_url: string;
     abbreviation: string;
+  }[];
+  concepts?: {
+    api_detail_url: string;
+    id: number;
+    name: string;
+    site_detail_url: string;
+  }[];
+  developers?: {
+    api_detail_url: string;
+    id: number;
+    name: string;
+    site_detail_url: string;
+  }[];
+  characters?: {
+    api_detail_url: string;
+    id: number;
+    name: string;
+    site_detail_url: string;
+  }[];
+  themes?: {
+    api_detail_url: string;
+    id: number;
+    name: string;
+    site_detail_url: string;
   }[];
 };
 
@@ -40,7 +67,18 @@ export type GiantBombResponse = {
   number_of_page_results: number;
   number_of_total_results: number;
   status_code: number;
-  results: Game[];
+  results: { api_detail_url: string }[];
+};
+
+export type GiantBombGameResponse = {
+  error: 'OK' | 'ERROR'; // I can't remember what exactly these values can be, but just someting that isn't OK will be enough
+  version: string;
+  limit: number;
+  offset: number;
+  number_of_page_results: number;
+  number_of_total_results: number;
+  status_code: number;
+  results: Game;
 };
 
 async function getMaxGamesNumber(token: string) {
@@ -65,7 +103,7 @@ async function getGame(token: string, max: number) {
   // random number between the first index (0) and the last index (length -1).
   const random = Math.floor(Math.random() * (max - 1));
   const response = await fetch(
-    `https://www.giantbomb.com/api/games/?api_key=${token}&limit=1&&format=json&offset=${random}`,
+    `https://www.giantbomb.com/api/games/?api_key=${token}&limit=1&format=json&offset=${random}&field_list=api_detail_url`,
   );
   const parsed = (await response.json()) as GiantBombResponse;
 
@@ -81,7 +119,44 @@ async function getGame(token: string, max: number) {
     );
   }
 
-  return parsed.results[0];
+  const { api_detail_url } = parsed.results[0];
+  if (!api_detail_url) {
+    throw new Error(
+      `GiantBomb query with no api_detail_url. offset: (${random}), max: (${max})`,
+    );
+  }
+
+  const fields = [
+    'name',
+    'site_detail_url',
+    'themes',
+    'platforms',
+    'original_release_date',
+    'image',
+    'id',
+    'guid',
+    'expected_release_year',
+    'expected_release_quarter',
+    'expected_release_month',
+    'expected_release_day',
+    'developers',
+    'deck',
+    'description',
+    'concepts',
+    'characters',
+  ].join(',');
+  const gameResponse = await fetch(
+    `${api_detail_url}?api_key=${token}&format=json&field_list=${fields}`,
+  );
+  const gameResponseJson = (await gameResponse.json()) as GiantBombGameResponse;
+
+  if (gameResponseJson.error != 'OK') {
+    throw new Error(
+      `Failed request to GiantBomb for game. error status (${parsed.error}), offset: (${random}), max: (${max})`,
+    );
+  }
+
+  return gameResponseJson.results;
 }
 
 export async function getRandomGotd(token: string) {


### PR DESCRIPTION
return the full game details rather than just the games response object. this way users can get the `themes`, `concepts`, `characters`, `developers`, and more.